### PR TITLE
parameterized VPC CIDR block was not being

### DIFF
--- a/multi-node/splunk_deployment_new_VPC.json
+++ b/multi-node/splunk_deployment_new_VPC.json
@@ -105,7 +105,9 @@
   "VPC": {
    "Type": "AWS::EC2::VPC",
    "Properties": {
-    "CidrBlock": "10.0.0.0/16",
+    "CidrBlock": {
+     "Ref": "VPCCIDR"
+    },
     "Tags": [
      {
       "Key": "Application",


### PR DESCRIPTION
The parameter for "VPCCIDR" was not being included int he VPC definition -- instead it was simply using the default. This change fixes that.